### PR TITLE
Fix: Remove redundant body font-family from globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,5 +22,4 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
Reviewed the codebase for errors, architectural issues, and UX conflicts.

The primary code change is the removal of a redundant `font-family: Arial, Helvetica, sans-serif;` declaration from the `body` tag in `src/app/globals.css`. This rule was potentially conflicting with or overriding the font settings provided by `next/font` (Geist Sans/Mono) and Tailwind CSS's font utilities.

Other findings from the review include suggestions for updating generic metadata, using more idiomatic Tailwind CSS classes, and considerations for future Tailwind configuration if needed. No critical errors were found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated global styles by removing the explicit font-family setting for the body element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->